### PR TITLE
deps: update react deps to peerdeps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ run/
 *.swp
 .vscode
 *.iml
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -15,9 +15,10 @@
     "egg-view",
     "react"
   ],
-  "dependencies": {
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+  "dependencies": {},
+  "peerDependencies": {
+    "react": "*",
+    "react-dom": "*"
   },
   "devDependencies": {
     "autod": "^2.8.0",
@@ -28,6 +29,8 @@
     "egg-mock": "^3.7.0",
     "eslint": "^3.19.0",
     "eslint-config-egg": "^4.2.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "supertest": "^3.0.0",
     "webstorm-disable-index": "^1.2.0"
   },

--- a/test/egg-view-react.test.js
+++ b/test/egg-view-react.test.js
@@ -27,7 +27,6 @@ describe('test/egg-view-react.test.js', () => {
       .get('/hello')
       .expect(200)
       .expect(res => {
-        assert(res.text.includes('data-react-checksum'));
         assert(res.text.includes('react server side render!'));
       });
   });
@@ -36,7 +35,6 @@ describe('test/egg-view-react.test.js', () => {
       .get('/markup')
       .expect(200)
       .expect(res => {
-        assert(!res.text.includes('data-react-checksum'));
         assert(res.text.includes('react server side render!'));
       });
   });


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change

目前插件直接依赖的 react 和 react-dom 为 dependencies，导致项目不能升级。 现改为   "peerDependencies"， 由项目自己根据React版本安装依赖。本次修改不涉及API修改， egg-view-react 本次修改依然支持 15 和 16.  看看是发小版本还是大版本。

```js
"dependencies": {
    "react": "^15.6.0",
    "react-dom": "^15.6.0"
  },
```

to

```js
"peerDependencies": {
    "react": "*",
    "react-dom": "*"
},
```